### PR TITLE
Master fix ios response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Releases
+1.1.0-j5.1
+- Fixed missing javascript plugin callback when sending server respond
+
+
 # cordova-plugin-webserver
 *A webserver plugin for cordova*
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
     id="cordova-plugin-webserver"
-    version="1.1.0">
+    version="1.1.0-j5.1">
   <engines>
     <engine name="cordova" version=">=6.5.0" />
   </engines>

--- a/src/ios/Webserver.swift
+++ b/src/ios/Webserver.swift
@@ -114,6 +114,8 @@
     @objc(sendResponse:)
     func sendResponse(_ command: CDVInvokedUrlCommand) {
         self.responses[command.argument(at: 0) as! String] = command.argument(at: 1)
+        let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK)
+        self.commandDelegate!.send(pluginResult, callbackId: command.callbackId)
     }
 
     @objc(start:)


### PR DESCRIPTION
This MR fixed that the plugin on iOS does not feedback once a server response is sent. 

**Test:**

- The success callback is now called when using webserver.sendResponse method